### PR TITLE
No Hungarian notation for parameters

### DIFF
--- a/src/zif_abap_serverless_v1.intf.abap
+++ b/src/zif_abap_serverless_v1.intf.abap
@@ -15,12 +15,12 @@ INTERFACE zif_abap_serverless_v1 PUBLIC.
   METHODS
     run
       IMPORTING
-        iv_method      TYPE string
-        iv_path        TYPE string
-        iv_query       TYPE string
-        is_request     TYPE ty_http
+        method      TYPE string
+        path        TYPE string
+        query       TYPE string
+        request     TYPE ty_http
       RETURNING
-        rs_response    TYPE ty_http
+        response    TYPE ty_http
       RAISING
         cx_static_check.
 

--- a/src/zif_abap_serverless_v1.intf.abap
+++ b/src/zif_abap_serverless_v1.intf.abap
@@ -15,12 +15,12 @@ INTERFACE zif_abap_serverless_v1 PUBLIC.
   METHODS
     run
       IMPORTING
-        method      TYPE string
-        path        TYPE string
-        query       TYPE string
-        request     TYPE ty_http
+        method      TYPE string OPTIONAL
+        path        TYPE string OPTIONAL
+        query       TYPE string OPTIONAL
+        request     TYPE ty_http OPTIONAL
       RETURNING
-        response    TYPE ty_http
+        VALUE(response) TYPE ty_http
       RAISING
         cx_static_check.
 


### PR DESCRIPTION
As per the [clean ABAP](https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md) style guide, Hungarian notation is discouraged. 
Though historically fancied, I believe we shouldn’t carry it forward. 